### PR TITLE
prefer $evalAsync over $timeout and resolve Facebook.login when loadD…

### DIFF
--- a/lib/angular-facebook.js
+++ b/lib/angular-facebook.js
@@ -307,9 +307,8 @@
         this.$get = [
           '$q',
           '$rootScope',
-          '$timeout',
           '$window',
-          function($q, $rootScope, $timeout, $window) {
+          function($q, $rootScope, $window) {
             /**
              * This is the NgFacebook class to be retrieved on Facebook Service request.
              */
@@ -353,7 +352,7 @@
                 // for being able to use promises.
                 if (angular.isFunction(userFn) && angular.isNumber(userFnIndex)) {
                   args.splice(userFnIndex, 1, function(response) {
-                    $timeout(function() {
+                    $rootScope.$evalAsync(function() {
                       if (response && angular.isUndefined(response.error)) {
                         d.resolve(response);
                       } else {
@@ -367,14 +366,9 @@
                   });
                 }
 
-                // review(mrzmyr): generalize behaviour of isReady check
-                if (this.isReady()) {
-                  $window.FB.login.apply($window.FB, args);
-                } else {
-                  $timeout(function() {
-                    d.reject("Facebook.login() called before Facebook SDK has loaded.");
-                  });
-                }
+                loadDeferred.promise.then(function(FB) {
+                  FB.login.apply(FB, args);
+                });
 
                 return d.promise;
             };
@@ -408,7 +402,7 @@
                 // for being able to use promises.
                 if (angular.isFunction(userFn) && angular.isNumber(userFnIndex)) {
                   args.splice(userFnIndex, 1, function(response) {
-                    $timeout(function() {
+                    $rootScope.$evalAsync(function() {
 
                       if (response && angular.isUndefined(response.error)) {
                         d.resolve(response);
@@ -423,11 +417,9 @@
                   });
                 }
 
-                $timeout(function() {
-                  // Call when loadDeferred be resolved, meaning Service is ready to be used.
-                  loadDeferred.promise.then(function() {
-                    $window.FB[name].apply(FB, args);
-                  });
+                // Call when loadDeferred be resolved, meaning Service is ready to be used.
+                loadDeferred.promise.then(function() {
+                  $window.FB[name].apply(FB, args);
                 });
 
                 return d.promise;
@@ -441,12 +433,10 @@
 
               var d = $q.defer();
 
-              $timeout(function() {
-                // Call when loadDeferred be resolved, meaning Service is ready to be used
-                loadDeferred.promise.then(function() {
-                  $window.FB.XFBML.parse();
-                  d.resolve();
-                });
+              // Call when loadDeferred be resolved, meaning Service is ready to be used
+              loadDeferred.promise.then(function() {
+                $window.FB.XFBML.parse();
+                d.resolve();
               });
 
               return d.promise;
@@ -483,7 +473,7 @@
                 if (angular.isFunction(userFn) && angular.isNumber(userFnIndex)) {
                   args.splice(userFnIndex, 1, function(response) {
 
-                    $timeout(function() {
+                    $rootScope.$evalAsync(function() {
 
                       if (response && angular.isUndefined(response.error)) {
                         d.resolve(response);
@@ -498,11 +488,9 @@
                   });
                 }
 
-                $timeout(function() {
-                  // Call when loadDeferred be resolved, meaning Service is ready to be used
-                  loadDeferred.promise.then(function() {
-                    $window.FB.Event[name].apply(FB, args);
-                  });
+                // Call when loadDeferred be resolved, meaning Service is ready to be used
+                loadDeferred.promise.then(function() {
+                  $window.FB.Event[name].apply(FB, args);
                 });
 
                 return d.promise;
@@ -523,8 +511,7 @@
       '$rootScope',
       '$q',
       '$window',
-      '$timeout',
-      function($rootScope, $q, $window, $timeout) {
+      function($rootScope, $q, $window) {
         // Define global loadDeffered to notify when Service callbacks are safe to use
         loadDeferred = $q.defer();
 
@@ -536,7 +523,7 @@
          */
         $window.fbAsyncInit = function() {
           // Initialize our Facebook app
-          $timeout(function() {
+          $rootScope.$evalAsync(function() {
             if (!settings.appId) {
               throw 'Missing appId setting.';
             }
@@ -562,7 +549,7 @@
               'comment.remove': 'uncomment'
             }, function(mapped, name) {
               FB.Event.subscribe(name, function(response) {
-                $timeout(function() {
+                $rootScope.$evalAsync(function() {
                   $rootScope.$broadcast('Facebook:' + mapped, response);
                 });
               });


### PR DESCRIPTION
…eferred is resolved

`$rootScope.$evalAsync` will take advantage or the current digest cycle, if one is running. Because the API promises are guarded by `loadDeferred.promise(...)` we should be making use of those digests.

Having `Facebook.login` wait on `loadDeferred` just seems to make sense, that's what all the other methods do.